### PR TITLE
Fixed compilation with ruby 2.0 by properly including the CFLAGS in CXXF...

### DIFF
--- a/project/swig/ruby/extconf.rb
+++ b/project/swig/ruby/extconf.rb
@@ -64,6 +64,8 @@ if RUBY_PLATFORM =~ /linux/
   # Make sure the proper version boost libraries are detected first by changing ruby's create_makefile library declaration order
   orig_makefile.gsub!(/LIBS = \$\(LIBRUBYARG_SHARED\)(.+)/, "LIBS = \\1 \$\(LIBRUBYARG_SHARED\)");
   orig_makefile.gsub!(/(-o \$@ \$\(OBJS\))( \$\(LIBPATH\) \$\(DLDFLAGS\) \$\(LOCAL_LIBS\))( \$\(LIBS\))/, "\\1\\3\\2")
+  # Ruby 2.0 improperly generates CXXFLAGS without including CFLAGS which causes compilation to fail due to missing librets.h
+  orig_makefile.gsub!(/CXXFLAGS = \$\(CCDLFLAGS\)/, "CXXFLAGS = \$\(CFLAGS\)");
 end
 File.open("Makefile", "w") do |mfile|
   mfile << makefile_prefix


### PR DESCRIPTION
This fixes compilation on ruby 2.0 by replacing the improper generation of CXXFLAGS by ruby 2.0 to point to CFLAGS.
