### PR TITLE
Squelch warning with autoconf > 2.68

### DIFF
--- a/project/build/ac-macros/antlr.m4
+++ b/project/build/ac-macros/antlr.m4
@@ -30,7 +30,7 @@ AC_DEFUN([MY_TEST_ANTLR], [
         AC_MSG_CHECKING([whether linking with -lantlr in $antlr_prefix works])
         CPPFLAGS="$save_CFLAGS -I$antlr_prefix/include"
         LIBS="$save_LIBS -L$antlr_prefix/lib -lantlr"
-        AC_LINK_IFELSE([
+        AC_LINK_IFELSE([AC_LANG_SOURCE([
       #include <antlr/CommonAST.hpp>
       class TestAST : public ANTLR_USE_NAMESPACE(antlr)CommonAST {
       };
@@ -40,7 +40,7 @@ AC_DEFUN([MY_TEST_ANTLR], [
         TestAST testAST;
         return 0;
       }
-        ], [
+        ])], [
           AC_MSG_RESULT(yes)
           ANTLR_CFLAGS="-I$antlr_prefix/include"
           ANTLR_LIBS="-L$antlr_prefix/lib -lantlr"


### PR DESCRIPTION
Per the discussion at https://autotools.io/forwardporting/autoconf.html
the If-Else family of macros has a new safety switch to ensure that the
source being compiled is setting the expected defines up to that point.

Small change to antlr.m4 ACT_LINK_IFELSE macro.
