### PR TITLE
Fix triggering ctypes assertion (debug build) on Windows

### DIFF
--- a/project/librets/src/util.cpp
+++ b/project/librets/src/util.cpp
@@ -37,7 +37,7 @@ bool NS::isEmpty(string aString)
     string::iterator ch;
     for (ch = aString.begin(); ch != aString.end(); ch++)
     {
-        if (!isspace(*ch))
+        if (!isspace((unsigned char) *ch))
         {
             return false;
         }


### PR DESCRIPTION
Fix triggering ctypes assertion (debug build) on Windows:

_ASSERTE((unsigned)(c + 1) <= 256);