### PR TITLE
Case-insensitive parser for Content-Type reponse header.

### DIFF
--- a/project/librets/src/GetObjectResponse.cpp
+++ b/project/librets/src/GetObjectResponse.cpp
@@ -419,7 +419,7 @@ string GetObjectResponse::FindBoundary(string contentType)
         string parameter = ba::trim_copy(*i);
         string name;
         string boundary;
-        if (splitField(parameter, "=", name, boundary) && (name == "boundary"))
+        if (splitField(parameter, "=", name, boundary) && (ba::to_lower_copy(name) == "boundary"))
         {
             ba::trim(boundary);
             

--- a/project/librets/src/RetsSession.cpp
+++ b/project/librets/src/RetsSession.cpp
@@ -78,9 +78,10 @@ GetEncoding(RetsHttpResponsePtr httpResponse, librets::EncodingType defaultEncod
         string parameter = ba::trim_copy(*i);
         string name;
         string value;
-        if (splitField(parameter, "=", name, value) && (name == "charset"))
+        if (splitField(parameter, "=", name, value) && (ba::to_lower_copy(name) == "charset"))
         {
             ba::trim(value);
+            ba::to_lower(value);
 
             // Strip off leading and trailing quote, if it exists
             string::size_type quotePosition = value.find_first_of("\"");


### PR DESCRIPTION
"Content-type: text/xml; charset=ISO-8859-1" is not parsed correctly as the parse is case-sensitive.
HTTP headers and IANA charsets are supposed to be case-insensitive (see https://stackoverflow.com/questions/19391221/http-are-character-set-names-case-sensitive)