### PR TITLE
Feature/add php7 support

### DIFF
--- a/project/build/php.mk
+++ b/project/build/php.mk
@@ -3,6 +3,7 @@
 #
 
 PHP_BUILD		= ${PHP_DLL} 
+PHP_VERSION		= `php-config --vernum`
 
 PHP_CXX_FLAGS		= `${SWIG_LIBRETS_CONFIG} --cflags`
 PHP_DLL			= ${PHP_OBJ_DIR}/librets.${DLL}
@@ -14,8 +15,13 @@ PHP_SRC_DIR		= ${SWIG_DIR}/php5
 PHP_WRAP 		= ${PHP_OBJ_DIR}/librets_wrap.cpp
 
 ${PHP_WRAP}: ${SWIG_FILES} 
-	${SWIG} -c++ -php5 -o ${PHP_WRAP} \
-	-outdir ${PHP_OBJ_DIR} ${SWIG_DIR}/librets.i
+	if [ ${PHP_VERSION} -ge 70000 ]; then \
+		${SWIG} -c++ -php7 -o ${PHP_WRAP} \
+		-outdir ${PHP_OBJ_DIR} ${SWIG_DIR}/librets.i; \
+	else \
+		${SWIG} -c++ -php5 -o ${PHP_WRAP} \
+		-outdir ${PHP_OBJ_DIR} ${SWIG_DIR}/librets.i; \
+	fi	
 
 ${PHP_DLL}: ${PHP_WRAP} ${PHP_OBJ_DIR}/librets_wrap.o ${SWIG_BRIDGE_OBJ} ${LIBRETS_LIB}
 	${SWIG_LINK_ALLOW_UNDEFINED} -o ${PHP_DLL} ${PHP_OBJ_DIR}/librets_wrap.o \

--- a/project/swig/auto_ptr_release.i
+++ b/project/swig/auto_ptr_release.i
@@ -71,7 +71,7 @@ namespace std {
    ce = zend_lookup_class(class_name);
    zend_string_release(class_name);
 
-   if (FAILURE == ce) {
+   if (!ce) {
        SWIG_PHP_Error(E_ERROR, "Unable to locate class entry for TYPE.");
    }
 

--- a/project/swig/auto_ptr_release.i
+++ b/project/swig/auto_ptr_release.i
@@ -53,7 +53,7 @@ namespace std {
 #elif defined(SWIGPHP)
 
 %typemap(out) std::auto_ptr<TYPE>
-{
+%{
    // Release the auto_ptr and create a Zend resource.
    SWIG_SetPointerZval($result, (void *) $1.release(), $descriptor(TYPE *), SWIG_POINTER_OWN);
    // Now create the PHP object to contain the class to which the auto_ptr
@@ -99,7 +99,7 @@ namespace std {
    add_property_zval(obj, "_cPtr",_cPtr);
    *$result = *obj;
 #endif
-}
+%}
 #else
 #error "Unsupported SWIG language for auto_ptr_release"
 #endif


### PR DESCRIPTION
This is a pull request to add PHP 7 support for the PHP binding. It still maintains the support for PHP 5. I did not make changes that might be needed for the Makefile.vc as we work on Linux, but you can make whatever changes are needed for that. This was tested on Centos 7 with PHP 7.2.6 and PHP 5.6.32.