### PR TITLE
Added Dockerfile and script to build and run the image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:9.5
+RUN apt-get update && apt-get install -y \
+build-essential \
+ruby \
+ruby-dev \
+python3-dev \
+python3-pip \
+autoconf \
+swig \
+libboost-dev \
+libboost-filesystem-dev \
+libcurl4-openssl-dev \
+libexpat-dev \
+default-jdk
+ADD . / librets/
+WORKDIR /librets
+RUN ./autogen.sh && ./configure \
+--enable-depends \
+--enable-shared_dependencies \
+&& make \
+&& make install
+WORKDIR /

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# libRETS-Docker
+libRETS Docker is a RETS client library written in C++ (forked from the NAR library) built and packaged for Docker. This allows rapid development of RETS client applications by saving the developer from dealing with the RETS protocol details. The application writer can concentrate on their application thusly saving them time and money in the process.
+
+Platform : 
+OS - Debian 9.5
+
+Configured Language Bindings:
+Python 3
+Ruby 2.4
+
+Requirements:
+Docker
+
+Build and test image by running the librets-build-docker.sh script.
+
+```bash
+docker build -t librets:latest .
+docker run -it librets:latest /bin/bash
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Platform :
 OS - Debian 9.5
 
 Configured Language Bindings:
-Python 3
+Python 3, 
 Ruby 2.4
 
 Requirements:

--- a/docker-buid-run.sh
+++ b/docker-buid-run.sh
@@ -1,0 +1,2 @@
+docker build -t librets:latest .
+docker run -it librets:latest /bin/bash

--- a/docker-buid-run.sh
+++ b/docker-buid-run.sh
@@ -1,2 +1,0 @@
-docker build -t librets:latest .
-docker run -it librets:latest /bin/bash

--- a/librets-build-docker.sh
+++ b/librets-build-docker.sh
@@ -1,0 +1,2 @@
+docker build -t librets:latest .
+docker run -it librets:latest /bin/bash


### PR DESCRIPTION
Here is an initial attempt at Dockerizing the library using Debian 9.5. It currently builds the bindings for Python 3 and the Ruby MRI packaged with the distro. I've attached a build script that will build and tag the image locally as well as launch a bash shell into the image for testing. The build output and containerized code is stored in /librets in the container.