### PR TITLE
Add Action parameter to UpdateRequest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ vendorsrc/expat
 vendorsrc/openssl
 vendorsrc/pcre
 vendorsrc/swigwin
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,12 @@ project/swig/csharp/bin
 project/swig/csharp/lib
 
 project/swig/node.js/binding.gyp
+
+# vendor
+vendorsrc/antlr
+vendorsrc/boost
+vendorsrc/curl
+vendorsrc/expat
+vendorsrc/openssl
+vendorsrc/pcre
+vendorsrc/swigwin

--- a/project/librets/include/librets/UpdateRequest.h
+++ b/project/librets/include/librets/UpdateRequest.h
@@ -113,6 +113,20 @@ class UpdateRequest : public RetsHttpRequest
      * @param updateType A string containing the value of the update type.
      */
     void SetUpdateType(std::string updateType);
+
+     /**
+     * Returns the current value of the update parameter for the request.
+     *
+     * @return A string containing the value of the action.
+     */
+    const std::string GetUpdateAction();
+    
+    /**
+     * Set the value of the update action parameter for the current request.
+     *
+     * @param action A string containing the value of the action.
+     */
+    void SetUpdateAction(std::string action);
     
     /**
      * This requests the server update the record if there are no errors.
@@ -191,6 +205,7 @@ class UpdateRequest : public RetsHttpRequest
     static const char * RECORD_PARAMETER;
     static const char * RESOURCE_PARAMETER;
     static const char * UPDATE_TYPE_PARAMETER;
+    static const char * UPDATE_ACTION_PARAMETER;
     static const char * VALIDATE_PARAMETER;
     static const char * WARNING_RESPONSE_PARAMETER;
     
@@ -198,6 +213,7 @@ class UpdateRequest : public RetsHttpRequest
     StringMap       mFields;
     int             mFlag;
     std::string     mUpdateType;
+    std::string     mAction;
     StringMap       mWarnings;
 };
 

--- a/project/librets/src/UpdateRequest.cpp
+++ b/project/librets/src/UpdateRequest.cpp
@@ -36,11 +36,12 @@ const char * UpdateRequest::DELIMITER_PARAMETER = "Delimiter";
 const char * UpdateRequest::RECORD_PARAMETER = "Record";
 const char * UpdateRequest::RESOURCE_PARAMETER = "Resource";
 const char * UpdateRequest::UPDATE_TYPE_PARAMETER = "Type";
+const char * UpdateRequest::UPDATE_ACTION_PARAMETER = "Action";
 const char * UpdateRequest::VALIDATE_PARAMETER = "Validate";
 const char * UpdateRequest::WARNING_RESPONSE_PARAMETER = "WarningResponse";
 
 UpdateRequest::UpdateRequest(string resourceName, string className)
-    : mDelimiter("\t"), mFlag(UpdateRequest::UPDATE_OK), mUpdateType("")
+    : mDelimiter("\t"), mFlag(UpdateRequest::UPDATE_OK), mUpdateType(""), mAction("")
 {
     SetQueryParameter(CLASS_PARAMETER, className);
     SetQueryParameter(RESOURCE_PARAMETER, resourceName);
@@ -48,6 +49,7 @@ UpdateRequest::UpdateRequest(string resourceName, string className)
     SetDelimiter(mDelimiter);
     SetMethod(POST);
     SetUpdateType(mUpdateType);
+    SetUpdateAction(mAction);
     SetValidateFlag(mFlag);
 }
 
@@ -145,6 +147,17 @@ void UpdateRequest::SetUpdateType(string updateType)
 {
     mUpdateType = updateType;
     SetQueryParameter(UPDATE_TYPE_PARAMETER, mUpdateType);
+}
+
+const string UpdateRequest::GetUpdateAction()
+{
+    return mAction;
+}
+
+void UpdateRequest::SetUpdateAction(string action)
+{
+    mAction = action;
+    SetQueryParameter(UPDATE_ACTION_PARAMETER, mAction);
 }
 
 const int UpdateRequest::GetValidateFlag()


### PR DESCRIPTION
If merged this would resolve #42 by adding the ability to specify the `Action` parameter. I'm still in the process of trying to get this to build on Windows so I haven't had a chance to test this yet, but in general I believe this is all that is necessary. My concern is that the previous expectation was that Type would always be set and this code would attempt to send `Type=""` due to how it's currently initialized, but please correct me if I'm wrong.