### PR TITLE
Fixing Python version detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,56 @@
-FROM debian:9.5
+#  Hold on tight, this is going to be a bumpy ride
+#
+#  I wasn't able to get this building directly under Ubuntu 22.04.  However, I
+#  could get it to build on Debian 11, but that only has Python 3.9 where 22.04
+#  has 3.10.  So I was able to use Debian testing to bring in Python 3.10,
+#  because this wouldn't build entirely under Debian testing due to similar
+#  issues to what I was seeing in 22.04.
+#  
+#  Note, once Debian Testing moves on from Python 3.10, building under Ubuntu
+#  22.04 is going to be a lost cause until the core of this build issue is
+#  resolved.
+
+FROM debian:11.0
 RUN apt-get update && apt-get install -y \
 build-essential \
 ruby \
 ruby-dev \
-python3-dev \
-python3-pip \
 autoconf \
-swig \
 libboost-dev \
 libboost-filesystem-dev \
 libcurl4-openssl-dev \
 libexpat-dev \
+git \
 default-jdk
+#  install python3 from testing to get 3.10
+RUN bash -c "echo deb http://deb.debian.org/debian testing main >/etc/apt/sources.list.d/testing.list"
+COPY pin-all /etc/apt/preferences.d/990-pin-all
+COPY pin-python /etc/apt/preferences.d/991-pin-python
+RUN apt-get update && apt-get install -y \
+python3-dev \
+libpython3-dev \
+dh-python \
+devscripts \
+swig \
+python3-pip
+RUN dpkg -l | grep python3
+RUN dpkg -l | grep dh-python
+RUN dpkg -l | grep devscripts
 ADD . / librets/
 WORKDIR /librets
-RUN ./autogen.sh && ./configure \
+RUN autoupdate
+RUN tar cfz ../librets_1.6.5.orig.tar.gz -C .. librets
+#RUN autoconf
+RUN ./autogen.sh
+
+RUN ./configure \
 --enable-depends \
---enable-shared_dependencies \
-&& make \
-&& make install
+--disable-python \
+--enable-shared_dependencies
+
+RUN rm -rf debian
+RUN git clone https://github.com/realgo/librets-package debian
+RUN debuild || true
+
+RUN ls -l /*.deb
 WORKDIR /

--- a/pin-all
+++ b/pin-all
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=bullseye
+Pin-Priority: 1001

--- a/pin-python
+++ b/pin-python
@@ -1,0 +1,15 @@
+Package: python3*
+Pin: release a=testing
+Pin-Priority: 1001
+
+Package: dh-python*
+Pin: release a=testing
+Pin-Priority: 1001
+
+Package: devscripts*
+Pin: release a=testing
+Pin-Priority: 1001
+
+Package: swig*
+Pin: release a=testing
+Pin-Priority: 1001

--- a/project/build/ac-macros/swig.m4
+++ b/project/build/ac-macros/swig.m4
@@ -190,7 +190,7 @@ EOF
         if test "$my_use_python3" = "yes"; then
             AC_CHECK_PROG(PYTHON3, python3, python3, no)
             if test "$PYTHON3" != "no"; then
-                python3_version=`python3 -c "import sys; print(sys.version[[:3]] + (sys.abiflags if hasattr(sys, 'abiflags') else ''))" | tr -d "\n\r"`
+                python3_version=`python3 -c "import sys; print('.'.join(sys.version.split('.')[[:2]]) + (sys.abiflags if hasattr(sys, 'abiflags') else ''))" | tr -d "\n\r"`
                 python3_prefix=`python3 -c "import sys; print(sys.base_prefix if hasattr(sys, 'base_prefix') else sys.prefix)" | tr -d "\n\r"`
                 python3_h="$python3_prefix/include/python$python3_version/Python.h"
                 case $host_os in


### PR DESCRIPTION
The Python 3 detection uses the first 3 characters of the
sys.version, which works great for Python <=3.9 but fails
at Python 3.10 and above.  This fixes that and also makes
that changes for Python 2.